### PR TITLE
Updating Node LTS image

### DIFF
--- a/6.9.2/Dockerfile
+++ b/6.9.2/Dockerfile
@@ -1,4 +1,4 @@
- FROM node:6.9.1
+ FROM node:6.9.2
  MAINTAINER Nazim Lala <naziml@microsoft.com>
  
  RUN  npm install -g pm2 \


### PR DESCRIPTION
Node `6.9.2` was released today, so we mine as well update the App Service image to that since it hasn't been published to production yet. Let me know if you'd prefer to have a separate image, despite the fact that the list would begin to be getting pretty large. 