### PR TITLE
Adding Node v6.10.2

### DIFF
--- a/6.10.2/Dockerfile
+++ b/6.10.2/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:6.10.2
+MAINTAINER Azure App Services Container Images <appsvc-images@microsoft.com>
+ 
+COPY init_container.sh /bin/
+ 
+RUN  npm install -g pm2 \
+     && mkdir /pm2home     \
+     && chmod 777 /pm2home \
+     && rm -rf /pm2home/logs \
+     && ln -s /home/LogFiles /pm2home/logs \
+     && echo "root:Docker!" | chpasswd \
+     && apt update \
+     && apt install -y --no-install-recommends openssh-server \
+     && chmod 755 /bin/init_container.sh 
+
+COPY sshd_config /etc/ssh/
+
+EXPOSE 2222
+
+CMD ["/bin/init_container.sh"]

--- a/6.10.2/init_container.sh
+++ b/6.10.2/init_container.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+service ssh start
+touch /home/LogFiles/node_$WEBSITE_ROLE_INSTANCE_ID_out.log
+echo "$(date) Container started" >> /home/LogFiles/node_$WEBSITE_ROLE_INSTANCE_ID_out.log

--- a/6.10.2/sshd_config
+++ b/6.10.2/sshd_config
@@ -1,0 +1,21 @@
+# This is ssh server systemwide configuration file.
+#
+# /etc/sshd_config
+
+Port 			2222
+ListenAddress 		0.0.0.0
+LoginGraceTime 		180
+X11Forwarding 		yes
+Ciphers aes128-cbc,3des-cbc,aes256-cbc
+MACs hmac-sha1,hmac-sha1-96
+StrictModes 		yes
+SyslogFacility 		DAEMON
+PrintMotd 		      no
+IgnoreRhosts 		no
+RhostsAuthentication 	no
+RhostsRSAAuthentication yes
+RSAAuthentication 	no 
+PasswordAuthentication 	yes
+PermitEmptyPasswords 	no
+PermitRootLogin 	yes
+


### PR DESCRIPTION
This simply adds a new image for the latest Node LTS release, and corresponds to the [Kudu image PR](https://github.com/Azure-App-Service/kudu/pull/16) that added support for the same version.

Note: The 6.10.2 release was just made this morning, and even though the Docker image was created, it hasn't been uploaded to DockerHub yet. So let's wait to merge this until later this afternoon. I'll update this PR when it's been published.