### PR TITLE
Adding Node v6.10.3

### DIFF
--- a/6.10.3/Dockerfile
+++ b/6.10.3/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:6.10.3
+MAINTAINER Azure App Services Container Images <appsvc-images@microsoft.com>
+ 
+COPY init_container.sh /bin/
+ 
+RUN  npm install -g pm2 \
+     && mkdir /pm2home     \
+     && chmod 777 /pm2home \
+     && rm -rf /pm2home/logs \
+     && ln -s /home/LogFiles /pm2home/logs \
+     && echo "root:Docker!" | chpasswd \
+     && apt update \
+     && apt install -y --no-install-recommends openssh-server \
+     && chmod 755 /bin/init_container.sh 
+
+COPY sshd_config /etc/ssh/
+
+EXPOSE 2222
+
+CMD ["/bin/init_container.sh"]

--- a/6.10.3/init_container.sh
+++ b/6.10.3/init_container.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+service ssh start
+touch /home/LogFiles/node_$WEBSITE_ROLE_INSTANCE_ID_out.log
+echo "$(date) Container started" >> /home/LogFiles/node_$WEBSITE_ROLE_INSTANCE_ID_out.log

--- a/6.10.3/sshd_config
+++ b/6.10.3/sshd_config
@@ -1,0 +1,21 @@
+# This is ssh server systemwide configuration file.
+#
+# /etc/sshd_config
+
+Port 			2222
+ListenAddress 		0.0.0.0
+LoginGraceTime 		180
+X11Forwarding 		yes
+Ciphers aes128-cbc,3des-cbc,aes256-cbc
+MACs hmac-sha1,hmac-sha1-96
+StrictModes 		yes
+SyslogFacility 		DAEMON
+PrintMotd 		      no
+IgnoreRhosts 		no
+RhostsAuthentication 	no
+RhostsRSAAuthentication yes
+RSAAuthentication 	no 
+PasswordAuthentication 	yes
+PermitEmptyPasswords 	no
+PermitRootLogin 	yes
+


### PR DESCRIPTION
This is the companion PR to the [kudu change](https://github.com/Azure-App-Service/kudu/pull/23) to add Node v6.10.3 support. Note that the 6.10.3 Node image hasn't been published to DockerHub yet, so let's not merge this change until it has. I'll update this as soon as it's available.