### PR TITLE
node 10 should use npm 6

### DIFF
--- a/10.1.0/Dockerfile
+++ b/10.1.0/Dockerfile
@@ -23,7 +23,7 @@ RUN npm install -g pm2 \
      && apk add tcptraceroute \
      && apk add bash \
      && cd /opt/startup \
-     && npm install \
+     && npm install npm@latest -g \
      && chmod 755 /opt/startup/init_container.sh
 
 EXPOSE 2222 8080


### PR DESCRIPTION
node updates less frequently than npm
node 10 still uses npm 5.6 as default, this forces it to use the latest npm