### PR TITLE
Adding index

### DIFF
--- a/9.4.0/startup/default-static-site.js
+++ b/9.4.0/startup/default-static-site.js
@@ -1,7 +1,7 @@
 var express = require('express');
 var server = express();
 var options = {
-    index: 'hostingstart.html'
+    index: ['index.html','hostingstart.html']
 };
 server.use('/', express.static('/home/site/wwwroot', options));
 server.listen(process.env.PORT);


### PR DESCRIPTION
When deploying a static optimized build of an application using frameworks such as React, Vue or Angular. They default to index.html. Not hostingstart.html.

If possible it would be great to have default documents
![1](https://user-images.githubusercontent.com/28450223/41310636-af6facbc-6e47-11e8-8827-cb1992b91499.PNG)
 like its windows counterpart 

