### PR TITLE
Fix env vars export with special characters ('=' or ';')

### DIFF
--- a/10.1.0/startup/init_container.sh
+++ b/10.1.0/startup/init_container.sh
@@ -19,7 +19,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 # feature flag for remote debugging for with npm
 # set flag and restart site to remove these changes

--- a/10.10.0/startup/init_container.sh
+++ b/10.10.0/startup/init_container.sh
@@ -19,7 +19,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/4.4.7/startup/init_container.sh
+++ b/4.4.7/startup/init_container.sh
@@ -21,7 +21,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/4.5.0/startup/init_container.sh
+++ b/4.5.0/startup/init_container.sh
@@ -21,7 +21,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/4.8.3/startup/init_container.sh
+++ b/4.8.3/startup/init_container.sh
@@ -21,7 +21,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/4.8.4/startup/init_container.sh
+++ b/4.8.4/startup/init_container.sh
@@ -21,7 +21,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/6.10.3/startup/init_container.sh
+++ b/6.10.3/startup/init_container.sh
@@ -21,7 +21,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/6.11.0/startup/init_container.sh
+++ b/6.11.0/startup/init_container.sh
@@ -21,7 +21,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/6.11.1/startup/init_container.sh
+++ b/6.11.1/startup/init_container.sh
@@ -21,7 +21,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/6.11.5/startup/init_container.sh
+++ b/6.11.5/startup/init_container.sh
@@ -21,7 +21,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/6.2.2/startup/init_container.sh
+++ b/6.2.2/startup/init_container.sh
@@ -21,7 +21,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/6.6.0/startup/init_container.sh
+++ b/6.6.0/startup/init_container.sh
@@ -21,7 +21,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/8.0.0/startup/init_container.sh
+++ b/8.0.0/startup/init_container.sh
@@ -21,7 +21,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/8.1.2/startup/init_container.sh
+++ b/8.1.2/startup/init_container.sh
@@ -21,7 +21,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/8.1.3/startup/init_container.sh
+++ b/8.1.3/startup/init_container.sh
@@ -21,7 +21,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/8.1.4/startup/init_container.sh
+++ b/8.1.4/startup/init_container.sh
@@ -21,7 +21,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/8.11.4/startup/init_container.sh
+++ b/8.11.4/startup/init_container.sh
@@ -19,7 +19,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/8.12.0/startup/init_container.sh
+++ b/8.12.0/startup/init_container.sh
@@ -19,7 +19,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/8.2.1/startup/init_container.sh
+++ b/8.2.1/startup/init_container.sh
@@ -21,7 +21,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/8.8.0/startup/init_container.sh
+++ b/8.8.0/startup/init_container.sh
@@ -21,7 +21,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/8.8.1/startup/init_container.sh
+++ b/8.8.1/startup/init_container.sh
@@ -21,7 +21,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/8.9.4/startup/init_container.sh
+++ b/8.9.4/startup/init_container.sh
@@ -21,7 +21,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js

--- a/9.4.0/startup/init_container.sh
+++ b/9.4.0/startup/init_container.sh
@@ -19,7 +19,7 @@ chmod 777 "$PM2HOME"
 ln -s /home/LogFiles "$PM2HOME"/logs
 
 # Get environment variables to show up in SSH session
-eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
+eval $(printenv | sed -e 's/^\([^=]*\)=\(.*\)$/export \1="\2"/g' >> /etc/profile)
 
 echo "$@" > /opt/startup/startupCommand
 node /opt/startup/generateStartupCommand.js


### PR DESCRIPTION
Hi guys,

Just found a problematic issue when I was trying to use your Node image as a Web App Container with a connection string to an Azure SQL database.

 By default, Azure setup a default connection string as follow:

`Database={database_name};Data Source={source};User Id={user};Password={password}`

_Note the '=' characters in the value section of the variable_

Which is injected in the container like this:

`MYSQLCONNSTR_defaultConnection=Database={database_name};Data Source={source};User Id={user};Password={password}`

However, in the script `init_container.sh`, we have the following line:

```bash
# Get environment variables to show up in SSH session
eval $(printenv | awk -F= '{print "export " $1"="$2 }' >> /etc/profile)
```

`awk -F=` use the `=` character as separator for the regex, and in this case, `$2` is equal to `Database` while we would expect the whole value.

I switch to `sed` because `awk` has trouble with non-greedy regex and use a new regex

I also escape values because with values with `;`:

`MYSQLCONNSTR_defaultConnection=Database={database_name};Data Source={source};User Id={user};Password={password}`

became

```
MYSQLCONNSTR_defaultConnection=Database={database_name};
Data Source={source}; <= Error: Data not found
User Id={user}; <= Error: User not found
Password={password} <= $Password stored as env var
```